### PR TITLE
Store TOTP data in KeePass vault per user

### DIFF
--- a/src/open_authenticator/api.py
+++ b/src/open_authenticator/api.py
@@ -1,8 +1,50 @@
+from __future__ import annotations
 from datetime import datetime
+import os
+import logging
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 import pyotp
+
+from .kdbx_manager import KdbxManager
+
+VAULT_DIR = Path(os.environ.get("VAULT_DIR", "./vaults"))
+VAULT_DIR.mkdir(parents=True, exist_ok=True)
+VAULT_PASSWORD = os.environ.get("VAULT_PASSWORD", "ChangeMe!")
+
+
+def _get_manager(user: str) -> KdbxManager:
+    """Open or create a vault for the given user."""
+    manager = KdbxManager(log_level=logging.ERROR)
+    vault_path = VAULT_DIR / f"{user}.kdbx"
+    if vault_path.exists():
+        manager.open_database(str(vault_path), password=VAULT_PASSWORD)
+    else:
+        manager.create_database(str(vault_path), password=VAULT_PASSWORD)
+    return manager
+
+
+def _entry_to_totp(entry) -> TOTPCreate | None:
+    """Convert a KDBX entry to ``TOTPCreate`` if possible."""
+    secret = entry.get_custom_property("2fa")
+    if not secret:
+        return None
+
+    issuer = entry.get_custom_property("issuer")
+    period = entry.get_custom_property("period")
+    created = entry.get_custom_property("created_at")
+    created_dt = datetime.fromisoformat(created) if created else datetime.utcnow()
+
+    return TOTPCreate(
+        label=entry.title,
+        login_id=entry.username or "",
+        secret=secret,
+        issuer=issuer,
+        period=int(period) if period else 30,
+        created_at=created_dt,
+    )
 
 app = FastAPI(title="openAuthenticator")
 
@@ -14,102 +56,128 @@ class TOTPCreate(BaseModel):
     period: int = 30  # Default to 30 seconds per RFC 6238
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-# In-memory store mapping user -> labels -> TOTP entries
-_totps: dict[str, dict[str, TOTPCreate]] = {}
 
 @app.post("/users/{user}/totp")
 def add_totp(user: str, data: TOTPCreate):
-    user_totps = _totps.setdefault(user, {})
-    if data.label in user_totps:
-        raise HTTPException(status_code=400, detail="TOTP already exists")
-    
-    # Try to parse URI if secret looks like a otpauth:// URI
-    if data.secret.startswith('otpauth://totp/'):
-        try:
-            # Extract parameters from the URI
-            import urllib.parse
-            uri = data.secret
-            parsed = urllib.parse.urlparse(uri)
-            params = dict(urllib.parse.parse_qsl(parsed.query))
-            
-            # Extract the actual secret and other parameters
-            if 'secret' in params:
-                data.secret = params['secret']
-            if 'period' in params:
-                data.period = int(params['period'])
-            if 'issuer' in params:
-                data.issuer = params['issuer']
-        except Exception as e:
-            # If parsing fails, keep the original data
-            print(f"Error parsing TOTP URI: {e}")
-    
-    # Clean and validate the secret key
+    manager = _get_manager(user)
     try:
-        # Remove spaces, make uppercase and strip padding if present
+        if manager.find_entries(title=data.label):
+            raise HTTPException(status_code=400, detail="TOTP already exists")
+
+        # Try to parse URI if secret looks like a otpauth:// URI
+        if data.secret.startswith('otpauth://totp/'):
+            try:
+                import urllib.parse
+                uri = data.secret
+                parsed = urllib.parse.urlparse(uri)
+                params = dict(urllib.parse.parse_qsl(parsed.query))
+
+                if 'secret' in params:
+                    data.secret = params['secret']
+                if 'period' in params:
+                    data.period = int(params['period'])
+                if 'issuer' in params:
+                    data.issuer = params['issuer']
+            except Exception as e:
+                print(f"Error parsing TOTP URI: {e}")
+
+        # Clean and validate the secret key
         data.secret = data.secret.replace(" ", "").upper().rstrip('=')
-        
-        # Validate that the secret is actually valid base32
         test_totp = pyotp.TOTP(data.secret)
-        # Generate a code to check if it works (will raise ValueError if invalid)
         test_totp.now()
-        
-        user_totps[data.label] = data
+
+        entry = manager.add_entry(
+            title=data.label,
+            username=data.login_id,
+            password="",
+        )
+        manager.add_custom_field(entry, "2fa", data.secret, protect=True)
+        manager.add_custom_field(entry, "period", str(data.period))
+        manager.add_custom_field(entry, "created_at", data.created_at.isoformat())
+        if data.issuer:
+            manager.add_custom_field(entry, "issuer", data.issuer)
+
+        manager.save()
         return {"message": f"Added {data.label}"}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid TOTP secret: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error creating TOTP: {str(e)}")
+    finally:
+        manager.close()
 
 @app.delete("/users/{user}/totp/{label}")
 def delete_totp(user: str, label: str):
-    user_totps = _totps.get(user)
-    if not user_totps or label not in user_totps:
-        raise HTTPException(status_code=404, detail="TOTP not found")
-    del user_totps[label]
-    return {"message": f"Deleted {label}"}
+    manager = _get_manager(user)
+    try:
+        entries = manager.find_entries(title=label)
+        if not entries:
+            raise HTTPException(status_code=404, detail="TOTP not found")
+        manager.delete_entry(entries[0])
+        manager.save()
+        return {"message": f"Deleted {label}"}
+    finally:
+        manager.close()
 
 @app.get("/users/{user}/totp")
 def list_totps(user: str):
-    return list(_totps.get(user, {}).values())
+    manager = _get_manager(user)
+    try:
+        results = []
+        for entry in manager.find_entries():
+            totp = _entry_to_totp(entry)
+            if totp:
+                results.append(totp)
+        return results
+    finally:
+        manager.close()
 
 @app.get("/users/{user}/totp/{label}")
 def get_totp(user: str, label: str):
-    entry = _totps.get(user, {}).get(label)
-    if not entry:
-        raise HTTPException(status_code=404, detail="TOTP not found")
-    return entry
+    manager = _get_manager(user)
+    try:
+        entries = manager.find_entries(title=label)
+        if not entries:
+            raise HTTPException(status_code=404, detail="TOTP not found")
+        totp = _entry_to_totp(entries[0])
+        if not totp:
+            raise HTTPException(status_code=404, detail="TOTP not found")
+        return totp
+    finally:
+        manager.close()
 
 @app.get("/users/{user}/totp/{label}/code")
 def get_current_code(user: str, label: str):
-    entry = _totps.get(user, {}).get(label)
-    if not entry:
-        raise HTTPException(status_code=404, detail="TOTP not found")
-    
+    manager = _get_manager(user)
     try:
-        # Clean the secret to ensure it's valid base32
-        secret = entry.secret.replace(" ", "").upper().rstrip('=')
-        
-        # Use the period from the entry, or default to 30 seconds
-        period = getattr(entry, "period", 30)
+        entries = manager.find_entries(title=label)
+        if not entries:
+            raise HTTPException(status_code=404, detail="TOTP not found")
+
+        entry = entries[0]
+        secret = entry.get_custom_property("2fa")
+        period = entry.get_custom_property("period") or 30
+        if not secret:
+            raise HTTPException(status_code=404, detail="TOTP not found")
+
+        secret = secret.replace(" ", "").upper().rstrip("=")
+        period = int(period)
         totp = pyotp.TOTP(secret, interval=period)
-        
-        # Calculate remaining time for this TOTP code based on the period
+
         now = datetime.utcnow()
         remaining = period - (now.timestamp() % period)
-        progress = (period - remaining) / period  # Progress from 0 to 1
-        
+        progress = (period - remaining) / period
+
         return {
-            "label": label, 
+            "label": label,
             "code": totp.now(),
             "remaining_seconds": remaining,
             "progress": progress,
-            "period": period  # Include the period in the response
+            "period": period,
         }
     except ValueError as e:
-        # If there's a problem with the secret format
-        raise HTTPException(
-            status_code=400, 
-            detail=f"Invalid TOTP secret for {label}: {str(e)}. Please delete and re-add this entry."
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid TOTP secret for {label}: {str(e)}. Please delete and re-add this entry.")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error generating TOTP code: {str(e)}")
+    finally:
+        manager.close()

--- a/src/tests/api_vault_test.py
+++ b/src/tests/api_vault_test.py
@@ -1,0 +1,23 @@
+import os
+import importlib
+from pathlib import Path
+from src.open_authenticator import api
+
+def test_add_totp_to_vault(tmp_path, monkeypatch):
+    monkeypatch.setenv("VAULT_DIR", str(tmp_path))
+    monkeypatch.setenv("VAULT_PASSWORD", "testpass")
+    importlib.reload(api)
+
+    data = api.TOTPCreate(label="example", login_id="user", secret="JBSWY3DPEHPK3PXP")
+    api.add_totp("alice", data)
+
+    manager = api._get_manager("alice")
+    try:
+        entries = manager.find_entries(title="example")
+        assert entries, "Entry not created"
+        entry = entries[0]
+        assert entry.username == "user"
+        assert entry.get_custom_property("2fa") == "JBSWY3DPEHPK3PXP"
+    finally:
+        manager.close()
+


### PR DESCRIPTION
## Summary
- switch TOTP API to store secrets inside a per-user KeePass (kdbx) file
- add helper functions for opening/creating vaults
- implement CRUD operations against the vaults
- add regression test covering vault storage

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684e945d5774832b97cf448a097e1303